### PR TITLE
Fix: Name is now updated when changed in JupiterWeb

### DIFF
--- a/src/user/services/scrapJupiter.ts
+++ b/src/user/services/scrapJupiter.ts
@@ -253,6 +253,17 @@ const getScrapJupiter = async (nUsp: string, password: string, retry: number = 0
           },
         })
       }
+
+      if (name != user.name) {
+        await prisma.user.update({
+          where: {
+            id: user.id,
+          },
+          data: {
+            name: name
+          },
+        })
+      }
     }
 
     if (!user) {


### PR DESCRIPTION
# Name Update

Adds a new bd update when the scrapped name is different from db.

I could not test it, as there is absolutely no documentation.

This aims to fix the following issue:

https://github.com/USPCodeLabSanca/folki-backend/issues/39